### PR TITLE
Fix L7 support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
         "illuminate/database": "^6.0|^7.0",
         "illuminate/routing": "^6.0|^7.0",
         "cviebrock/eloquent-sluggable": "^6.0|^7.0",
-        "arcanedev/seo-helper": "^2.0"
+        "arcanedev/seo-helper": "^2.0|^3.0"
     },
     "require-dev": {
         "orchestra/testbench": "^4.0|^5.0",


### PR DESCRIPTION
The `arcanedev/seo-helper` package was still blocking Laravel 7 compatibility.